### PR TITLE
Update group element methods

### DIFF
--- a/src/cmlibs/utils/zinc/group.py
+++ b/src/cmlibs/utils/zinc/group.py
@@ -122,7 +122,7 @@ def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, hig
                     if mesh_group.isValid():
                         mesh_group.removeElementsConditional(conditional_group)
                 if highest_dimension_only:
-                    return
+                    break
             elif dimension == 0:
                 nodeset = other_fieldmodule.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
                 if nodeset.getSize() == 0:

--- a/src/cmlibs/utils/zinc/group.py
+++ b/src/cmlibs/utils/zinc/group.py
@@ -13,20 +13,21 @@ class GroupOperator(Enum):
     REMOVE = 2  # Remove elements/nodes from the selected group.
 
 
-def group_add_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension_only=True):
+def group_add_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
     """
     Add to group elements and/or nodes from other_group, which may be in the same or a descendent region.
     Note only objects from other_group's region are added.
 
     :param group: The FieldGroup to modify.
     :param other_group: FieldGroup within region tree of group's region to add contents from.
+    :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only add elements of highest dimension mesh group present in other_group,
         otherwise do this for all dimensions.
     """
-    _group_update_group_elements(group, other_group, highest_dimension_only, GroupOperator.ADD)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.ADD)
 
 
-def group_add_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension_only=True):
+def group_add_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
     """
     Add to group elements and/or nodes from the underlying model that are not in other_group, which may be in the same or a descendent
     region.
@@ -34,26 +35,28 @@ def group_add_not_group_elements(group: FieldGroup, other_group: FieldGroup, hig
 
     :param group: The FieldGroup to modify.
     :param other_group: FieldGroup within region tree of group's region whose complement elements should be added to group.
+    :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only add elements not in the highest dimension mesh group present in other_group,
         otherwise do this for all dimensions.
     """
-    _group_update_group_elements(group, other_group, highest_dimension_only, GroupOperator.ADD, complement=True)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.ADD, complement=True)
 
 
-def group_remove_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension_only=True):
+def group_remove_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
     """
     Remove from group elements and/or nodes from other_group, which may be in the same or a descendent region.
     Note only objects from other_group's region are removed.
 
     :param group: The FieldGroup to modify.
     :param other_group: FieldGroup within region tree of group's region whose elements should be removed from group.
+    :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only remove elements of highest dimension present in other_group, otherwise remove
         elements of all dimensions.
     """
-    _group_update_group_elements(group, other_group, highest_dimension_only, GroupOperator.REMOVE)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.REMOVE)
 
 
-def group_remove_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension_only=True):
+def group_remove_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
     """
     Remove from group elements and/or nodes from the underlying model that are not in other_group, which may be in the same or a descendent
     region.
@@ -61,18 +64,21 @@ def group_remove_not_group_elements(group: FieldGroup, other_group: FieldGroup, 
 
     :param group: The FieldGroup to modify.
     :param other_group: FieldGroup within region tree of group's region whose complement elements should be removed from group.
+    :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only remove elements not in the highest dimension mesh group present in other_group,
         otherwise do this for all dimensions.
     """
-    _group_update_group_elements(group, other_group, highest_dimension_only, GroupOperator.REMOVE, complement=True)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.REMOVE, complement=True)
 
 
-def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension_only, operation, complement=False):
+def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension, highest_dimension_only, operation,
+                                 complement=False):
     """
     Base function for add/remove group-elements functions.
 
     :param group: The FieldGroup to modify.
     :param other_group: FieldGroup within region tree of group's region to use a basis for add/remove operation.
+    :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only consider elements in the highest dimension mesh group present in other_group,
         otherwise do this for all dimensions. Note this includes dimension 0 = nodes.
     :param operation: The operation (Add or Remove) to be performed on the groups.
@@ -83,7 +89,7 @@ def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, hig
     with HierarchicalChangeManager(region):
         other_fieldmodule = other_group.getFieldmodule()
         conditional_group = other_fieldmodule.createFieldNot(other_group) if complement else other_group
-        for dimension in range(3, -1, -1):
+        for dimension in range(highest_dimension, -1, -1):
             if dimension > 0:
                 mesh = other_fieldmodule.findMeshByDimension(dimension)
                 if mesh.getSize() == 0:

--- a/src/cmlibs/utils/zinc/group.py
+++ b/src/cmlibs/utils/zinc/group.py
@@ -13,7 +13,8 @@ class GroupOperator(Enum):
     REMOVE = 2  # Remove elements/nodes from the selected group.
 
 
-def group_add_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
+def group_add_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True,
+                             conditional_field=None):
     """
     Add to group elements and/or nodes from other_group, which may be in the same or a descendent region.
     Note only objects from other_group's region are added.
@@ -23,11 +24,14 @@ def group_add_group_elements(group: FieldGroup, other_group: FieldGroup, highest
     :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only add elements of highest dimension mesh group present in other_group,
         otherwise do this for all dimensions.
+    :param conditional_field: Zinc Field specifying a condition-based subset of elements from other_group to be used for the operation.
+        If None (default) the operation will use the entire set of elements from other_group.
     """
-    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.ADD)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, conditional_field, GroupOperator.ADD)
 
 
-def group_add_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
+def group_add_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True,
+                                 conditional_field=None):
     """
     Add to group elements and/or nodes from the underlying model that are not in other_group, which may be in the same or a descendent
     region.
@@ -38,11 +42,15 @@ def group_add_not_group_elements(group: FieldGroup, other_group: FieldGroup, hig
     :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only add elements not in the highest dimension mesh group present in other_group,
         otherwise do this for all dimensions.
+    :param conditional_field: Zinc Field specifying a condition-based subset of elements from other_group to be used for the operation.
+        If None (default) the operation will use the entire set of elements from other_group.
     """
-    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.ADD, complement=True)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, conditional_field, GroupOperator.ADD,
+                                 complement=True)
 
 
-def group_remove_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
+def group_remove_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True,
+                                conditional_field=None):
     """
     Remove from group elements and/or nodes from other_group, which may be in the same or a descendent region.
     Note only objects from other_group's region are removed.
@@ -52,11 +60,14 @@ def group_remove_group_elements(group: FieldGroup, other_group: FieldGroup, high
     :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only remove elements of highest dimension present in other_group, otherwise remove
         elements of all dimensions.
+    :param conditional_field: Zinc Field specifying a condition-based subset of elements from other_group to be used for the operation.
+        If None (default) the operation will use the entire set of elements from other_group.
     """
-    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.REMOVE)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, conditional_field, GroupOperator.REMOVE)
 
 
-def group_remove_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True):
+def group_remove_not_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension=3, highest_dimension_only=True,
+                                    conditional_field=None):
     """
     Remove from group elements and/or nodes from the underlying model that are not in other_group, which may be in the same or a descendent
     region.
@@ -67,12 +78,15 @@ def group_remove_not_group_elements(group: FieldGroup, other_group: FieldGroup, 
     :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only remove elements not in the highest dimension mesh group present in other_group,
         otherwise do this for all dimensions.
+    :param conditional_field: Zinc Zinc Field specifying a condition-based subset of elements from other_group to be used for the operation.
+        If None (default) the operation will use the entire set of elements from other_group.
     """
-    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, GroupOperator.REMOVE, complement=True)
+    _group_update_group_elements(group, other_group, highest_dimension, highest_dimension_only, conditional_field, GroupOperator.REMOVE,
+                                 complement=True)
 
 
-def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension, highest_dimension_only, operation,
-                                 complement=False):
+def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, highest_dimension, highest_dimension_only, conditional_field,
+                                 operation, complement=False):
     """
     Base function for add/remove group-elements functions.
 
@@ -81,6 +95,8 @@ def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, hig
     :param highest_dimension: The highest dimension of the mesh to be used for the operation.
     :param highest_dimension_only: If set (default), only consider elements in the highest dimension mesh group present in other_group,
         otherwise do this for all dimensions. Note this includes dimension 0 = nodes.
+    :param conditional_field: Zinc Field specifying a condition-based subset of elements from other_group to be used for the operation.
+        If None (default) the operation will use the entire set of elements from other_group.
     :param operation: The operation (Add or Remove) to be performed on the groups.
     :param complement: If set, other_group will be replaced with it's complement element group in the underlying model. Therefore the
         function will use all elements and/or nodes from the underlying model that are NOT in other_group as the basis of the operation.
@@ -88,7 +104,8 @@ def _group_update_group_elements(group: FieldGroup, other_group: FieldGroup, hig
     region = group.getFieldmodule().getRegion()
     with HierarchicalChangeManager(region):
         other_fieldmodule = other_group.getFieldmodule()
-        conditional_group = other_fieldmodule.createFieldNot(other_group) if complement else other_group
+        field = other_fieldmodule.createFieldAnd(other_group, conditional_field) if conditional_field else other_group
+        conditional_group = other_fieldmodule.createFieldNot(field) if complement else field
         for dimension in range(highest_dimension, -1, -1):
             if dimension > 0:
                 mesh = other_fieldmodule.findMeshByDimension(dimension)


### PR DESCRIPTION
This PR adds two new parameters (`highest_dimension` and `conditional_field`) to the following group methods:

- group_add_group_elements
- group_add_not_group_elements
- group_remove_group_elements
- group_remove_not_group_elements

`highest_dimension` allows the user to specify the highest dimension of the mesh to be used for the operation.
`conditional_field` allows the user to specify a condition-based subset of elements from `other_group` to be used for the operation. By default this parameter is `None` and the operation will use the entire set of elements from `other_group`.